### PR TITLE
CollectionView 로드 로직 변경

### DIFF
--- a/PhotosApp/PhotosApp/PhotoDataManager.swift
+++ b/PhotosApp/PhotosApp/PhotoDataManager.swift
@@ -11,6 +11,7 @@ import Photos
 
 class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
     static let thumbnailImageSize = CGSize(width: 100, height: 100)
+    static let photoReload = "photoReload"
     static let photoRemoved = "photoRemoved"
     static let photoInserted = "photoInserted"
     static let photoChanged = "photoChanged"
@@ -40,21 +41,23 @@ class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
     }
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-            guard let changes = changeInstance.changeDetails(for: photoData) else { return }
-            photoData = changes.fetchResultAfterChanges
-            if changes.hasIncrementalChanges {
-                if let removed = changes.removedIndexes, removed.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil, userInfo: [PhotoDataManager.photoRemoved : removed])
-                }
-                if let inserted = changes.insertedIndexes, inserted.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil, userInfo: [PhotoDataManager.photoInserted : inserted])
-                }
-                if let changed = changes.changedIndexes, changed.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil, userInfo: [PhotoDataManager.photoChanged : changed])
-                }
-                changes.enumerateMoves { (fromIndex, toIndex) in
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
-                }
+        guard let changes = changeInstance.changeDetails(for: photoData) else { return }
+        photoData = changes.fetchResultAfterChanges
+        if changes.hasIncrementalChanges {
+            if let removed = changes.removedIndexes, removed.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil, userInfo: [PhotoDataManager.photoRemoved : removed])
             }
+            if let inserted = changes.insertedIndexes, inserted.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil, userInfo: [PhotoDataManager.photoInserted : inserted])
+            }
+            if let changed = changes.changedIndexes, changed.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil, userInfo: [PhotoDataManager.photoChanged : changed])
+            }
+            changes.enumerateMoves { (fromIndex, toIndex) in
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
+            }
+        } else {
+            NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoReload), object: nil)
+        }
     }
 }

--- a/PhotosApp/PhotosApp/PhotoDataManager.swift
+++ b/PhotosApp/PhotosApp/PhotoDataManager.swift
@@ -11,7 +11,10 @@ import Photos
 
 class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
     static let thumbnailImageSize = CGSize(width: 100, height: 100)
-    static let photoLibraryChanged = "photoLibraryChanged"
+    static let photoRemoved = "photoRemoved"
+    static let photoInserted = "photoInserted"
+    static let photoChanged = "photoChanged"
+    static let photoEnumerated = "photoEnumerated"
     private var photoData = PHAsset.fetchAssets(with: .image, options: nil)
     private let manager = PHImageManager.default()
     var photoCount: Int {
@@ -37,8 +40,21 @@ class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
     }
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-        guard let changes = changeInstance.changeDetails(for: photoData) else { return }
-        photoData = changes.fetchResultAfterChanges
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoLibraryChanged), object: nil)
+            guard let changes = changeInstance.changeDetails(for: photoData) else { return }
+            photoData = changes.fetchResultAfterChanges
+            if changes.hasIncrementalChanges {
+                if let removed = changes.removedIndexes, removed.count > 0 {
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil, userInfo: [PhotoDataManager.photoRemoved : removed])
+                }
+                if let inserted = changes.insertedIndexes, inserted.count > 0 {
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil, userInfo: [PhotoDataManager.photoInserted : inserted])
+                }
+                if let changed = changes.changedIndexes, changed.count > 0 {
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil, userInfo: [PhotoDataManager.photoChanged : changed])
+                }
+                changes.enumerateMoves { (fromIndex, toIndex) in
+                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
+                }
+            }
     }
 }

--- a/PhotosApp/PhotosApp/PhotoDataManager.swift
+++ b/PhotosApp/PhotosApp/PhotoDataManager.swift
@@ -56,11 +56,8 @@ class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
             changes.enumerateMoves { (fromIndex, toIndex) in
                 NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
             }
-<<<<<<< HEAD
         } else {
             NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoReload), object: nil)
-=======
->>>>>>> 90e897f205ab512c4117b966671235e2698e9149
         }
     }
 }

--- a/PhotosApp/PhotosApp/PhotoDataManager.swift
+++ b/PhotosApp/PhotosApp/PhotoDataManager.swift
@@ -40,21 +40,21 @@ class PhotoDataManager: NSObject, PHPhotoLibraryChangeObserver {
     }
     
     func photoLibraryDidChange(_ changeInstance: PHChange) {
-            guard let changes = changeInstance.changeDetails(for: photoData) else { return }
-            photoData = changes.fetchResultAfterChanges
-            if changes.hasIncrementalChanges {
-                if let removed = changes.removedIndexes, removed.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil, userInfo: [PhotoDataManager.photoRemoved : removed])
-                }
-                if let inserted = changes.insertedIndexes, inserted.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil, userInfo: [PhotoDataManager.photoInserted : inserted])
-                }
-                if let changed = changes.changedIndexes, changed.count > 0 {
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil, userInfo: [PhotoDataManager.photoChanged : changed])
-                }
-                changes.enumerateMoves { (fromIndex, toIndex) in
-                    NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
-                }
+        guard let changes = changeInstance.changeDetails(for: photoData) else { return }
+        photoData = changes.fetchResultAfterChanges
+        if changes.hasIncrementalChanges {
+            if let removed = changes.removedIndexes, removed.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil, userInfo: [PhotoDataManager.photoRemoved : removed])
             }
+            if let inserted = changes.insertedIndexes, inserted.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil, userInfo: [PhotoDataManager.photoInserted : inserted])
+            }
+            if let changed = changes.changedIndexes, changed.count > 0 {
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil, userInfo: [PhotoDataManager.photoChanged : changed])
+            }
+            changes.enumerateMoves { (fromIndex, toIndex) in
+                NotificationCenter.default.post(name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil, userInfo: [PhotoDataManager.photoEnumerated : (fromIndex, toIndex)])
+            }
+        }
     }
 }

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -13,6 +13,10 @@ class ViewController: UIViewController {
     
     private let photoDataSource = PhotoCollectionViewDataSource()
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         photoCollectionView.dataSource = photoDataSource

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -20,6 +20,12 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         photoCollectionView.dataSource = photoDataSource
+        addPhotoObservers()
+    }
+}
+
+extension ViewController {
+    func addPhotoObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(photoRemoveUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(photoInsertUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(photoChangeUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil)
@@ -66,4 +72,3 @@ class ViewController: UIViewController {
         }
     }
 }
-

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -20,10 +20,17 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         photoCollectionView.dataSource = photoDataSource
+        addPhotoObservers()
+    }
+}
+
+extension ViewController {
+    func addPhotoObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(photoRemoveUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(photoInsertUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(photoChangeUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(photoEnumerateUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(photoReloadUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoReload), object: nil)
     }
     
     @objc func photoRemoveUpdate(_ notification: Notification) {
@@ -65,5 +72,10 @@ class ViewController: UIViewController {
             }, completion: nil)
         }
     }
+    
+    @objc func photoReloadUpdate() {
+        DispatchQueue.main.sync {
+            self.photoCollectionView.reloadData()
+        }
+    }
 }
-

--- a/PhotosApp/PhotosApp/ViewController.swift
+++ b/PhotosApp/PhotosApp/ViewController.swift
@@ -20,12 +20,49 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         photoCollectionView.dataSource = photoDataSource
-        NotificationCenter.default.addObserver(self, selector: #selector(reloadCollectionView), name: NSNotification.Name(rawValue: PhotoDataManager.photoLibraryChanged), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(photoRemoveUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoRemoved), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(photoInsertUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoInserted), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(photoChangeUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoChanged), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(photoEnumerateUpdate), name: NSNotification.Name(rawValue: PhotoDataManager.photoEnumerated), object: nil)
     }
     
-    @objc func reloadCollectionView() {
-        DispatchQueue.main.async {
-            self.photoCollectionView.reloadData()
+    @objc func photoRemoveUpdate(_ notification: Notification) {
+        DispatchQueue.main.sync {
+            guard let receivedData = notification.userInfo else { return }
+            photoCollectionView.performBatchUpdates({
+                guard let index = receivedData[PhotoDataManager.photoRemoved] as? IndexSet else { return }
+                self.photoCollectionView.deleteItems(at: index.map { IndexPath(item: $0, section: 0) })
+            }, completion: nil)
+        }
+    }
+    
+    @objc func photoInsertUpdate(_ notification: Notification) {
+        DispatchQueue.main.sync {
+            guard let receivedData = notification.userInfo else { return }
+            photoCollectionView.performBatchUpdates({
+                guard let index = receivedData[PhotoDataManager.photoInserted] as? IndexSet else { return }
+                self.photoCollectionView.insertItems(at: index.map { IndexPath(item: $0, section: 0) })
+            }, completion: nil)
+        }
+    }
+    
+    @objc func photoChangeUpdate(_ notification: Notification) {
+        DispatchQueue.main.sync {
+            guard let receivedData = notification.userInfo else { return }
+            photoCollectionView.performBatchUpdates({
+                guard let index = receivedData[PhotoDataManager.photoChanged] as? IndexSet else { return }
+                self.photoCollectionView.reloadItems(at: index.map { IndexPath(item: $0, section: 0) })
+            }, completion: nil)
+        }
+    }
+    
+    @objc func photoEnumerateUpdate(_ notification: Notification) {
+        DispatchQueue.main.sync {
+            guard let receivedData = notification.userInfo else { return }
+            photoCollectionView.performBatchUpdates({
+                guard let index = receivedData[PhotoDataManager.photoEnumerated] as? (Int, Int) else { return }
+                self.photoCollectionView.moveItem(at: IndexPath(item: index.0, section: 0), to: IndexPath(item: index.1, section: 0))
+            }, completion: nil)
         }
     }
 }


### PR DESCRIPTION
PhotoLibrary 에 변동이 생길 때 마다 reloadData() 로 collectionView 전체를 로드해줬었는데 변경된 부분만 로드하도록 수정했습니다. ViewController 의 Notification 을 처리하는 부분이 길어져서 extension 으로 빼줬습니다.